### PR TITLE
Removing check that blocks creating datastore on non-flash devices

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -162,10 +162,6 @@ function New-VmfsDatastore {
         throw "Invalid Size $SizeInBytes provided. Size should be between 1 GB and 62 TB."
     }
 
-    if ($DeviceNaaId -notlike 'naa.624a9370*') {
-        throw "Invalid Device NAA ID $DeviceNaaId provided."
-    }
-
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {
         throw "Cluster $ClusterName does not exist."


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* ...
* ...
* ...

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

